### PR TITLE
Update flake.lock files

### DIFF
--- a/update-flake-lock/action.yaml
+++ b/update-flake-lock/action.yaml
@@ -49,7 +49,7 @@ runs:
         find . -name 'flake.lock' | while read lockfile; do
           (cd $(dirname $lockfile) && nix flake update)
           git add $lockfile
-          git commit -m "Update flake.lock in $(dirname $lockfile)"
+          git commit -m "Update ${lockfile}"
         done
 
     - name: Rebase onto main
@@ -105,7 +105,8 @@ runs:
       run: |
         git checkout ${{ inputs.main-branch }}
         git merge --squash ${{ inputs.update-branch }}
-        git commit -m "Squash merge flake.lock updates"
+        commit_messages=$(git log ${{ inputs.main-branch }}..${{ inputs.update-branch }} --pretty=format:"%s" | sed 's/^/- /')
+        git commit -m "flake.lock updates" -m "$commit_messages"
 
     - name: Push changes
       shell: bash


### PR DESCRIPTION
- Updates `flake.lock` files with a more specific commit message, referencing the individual `flake.lock` file path.
- Incorporates previous commit messages from the update branch when squashing merge commits to maintain thorough context.
- Modifies commit messages during merge squash operations to clearly signal “flake.lock updates.”