### PR TITLE
Add Nix flake check workflow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,19 @@
+---
+name: Nix Flake Check
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  nix-flake-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@main
+
+      - uses: DeterminateSystems/flake-checker-action@main


### PR DESCRIPTION
- Introduces a new workflow named `Nix Flake Check`.
- Configures the workflow to trigger on pushes to all branches.
- Uses `actions/checkout@v4` to checkout the code.
- Integrates `DeterminateSystems/nix-installer-action@main` to install Nix.
- Employs `DeterminateSystems/flake-checker-action@main` to check the Nix flake.