### PR TITLE
chore(ci): update Nix installer action in workflow

### DIFF
--- a/nix-build/action.yaml
+++ b/nix-build/action.yaml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Install Nix
-      uses: cachix/install-nix-action@v30
+      uses: DeterminateSystems/nix-installer-action@main
 
     - name: Compile
       id: compile


### PR DESCRIPTION
- Replace cachix/install-nix-action with DeterminateSystems/nix-installer-action for Nix installation step in GitHub Actions workflow