### PR TITLE
refactor: extract update logic into dedicated module with error handling

### DIFF
--- a/update-flake-lock/action.yaml
+++ b/update-flake-lock/action.yaml
@@ -71,34 +71,10 @@ runs:
       run: |
         source ${{ github.action_path }}/modules/mod.nu
 
-        let head_branch = "${{ inputs.update-branch }}"
-        let target_branch = "${{ inputs.main-branch }}"
-        let checks_required = "${{ inputs.checks-required }}" | str split ","
-
-        if ($head_branch | branch exists) {
-          $head_branch | branch switch 
-          if ($target_branch | branch rebase) {
-            $head_branch | branch push --force
-            echo $"Rebased latest from ($target_branch) onto ($head_branch)"
-            exit 0
-          }
-
-          let checks = (git rev-parse HEAD | commit checks --status "success" --checks-required $checks_required)
-          if (($checks | is-not-empty) or ($checks_required | is-empty)) {
-            $head_branch | branch merge --squash --into $target_branch
-            $target_branch | branch push
-            $head_branch | branch delete
-          }
-
+        let checks_required = if ("${{ inputs.checks-required }}" | is-empty) {
+          []
         } else {
-          $head_branch | branch create
-          mut flakes = (
-            (glob **/flake.nix) | each { |flake|
-              let relative_flake = ($flake | path relative-to $env.PWD)
-              $relative_flake | flake update 
-              $"Updated ($relative_flake)"
-            }
-          )
-          branch commit-all -m $"($flakes | str join "\n")"
-          $head_branch | branch push
+          "${{ inputs.checks-required }}" | str split ","
         }
+
+        update-flake-locks "${{ inputs.update-branch }}" "${{ inputs.main-branch }}" $checks_required

--- a/update-flake-lock/modules/flake_utils.nu
+++ b/update-flake-lock/modules/flake_utils.nu
@@ -1,8 +1,10 @@
 export def 'flake update' [] {
   let flake = $in
-  cd ($flake | path dirname)
-  nix flake update
-  cd -
 
-  $flake
+  try {
+    nix flake update --flake $flake
+    $flake
+  } catch {
+    error make {msg: $"Failed to update flake: ($flake)"}
+  }
 }

--- a/update-flake-lock/modules/git_utils.nu
+++ b/update-flake-lock/modules/git_utils.nu
@@ -49,7 +49,7 @@ export def 'branch delete' [] {
   $branch
 }
 
-export def 'branch merge' [ --into (-i): string = "main", --squash (-s)] {
+export def 'branch merge' [ --into (-i): string = "main" --squash (-s)] {
   let head_branch = $in
 
   git checkout $into
@@ -66,7 +66,7 @@ export def 'branch commit-all' [ --message (-m): string] {
   git commit -am $"($message)"
 }
 
-export def 'commit checks' [ --status: string = "success", --checks-required: list = []] {
+export def 'commit checks' [ --status: string = "success" --checks-required: list = []] {
   let commit = $in
 
   let checks = if ($checks_required | is-not-empty) {

--- a/update-flake-lock/modules/mod.nu
+++ b/update-flake-lock/modules/mod.nu
@@ -1,3 +1,4 @@
 export use ./git_utils.nu *
 export use ./flake_utils.nu *
 export use ./utils.nu *
+export use ./main.nu


### PR DESCRIPTION
## Summary
- Extracted all update logic from action.yaml into a dedicated main.nu module
- Improved error handling throughout the codebase
- Optimized flake update operations

## Changes
- **Moved logic to main.nu**: All the complex logic previously in action.yaml is now in a dedicated `update-flake-locks` function
- **Added error handling**: Comprehensive try/catch blocks with meaningful error messages
- **Optimized flake updates**: Now uses `--flake` option instead of changing directories
- **Fixed Nushell syntax**: Corrected parameter separator issues in git_utils.nu
- **Improved logging**: Added informative messages for all operations including rebase scenarios

## Test plan
- [ ] Test with a repository that has flake.nix files
- [ ] Test the rebase scenario when the update branch already exists
- [ ] Test with required checks configured
- [ ] Test error handling when no flake.nix files are found